### PR TITLE
Extract link and domain name verification logic into seperate services

### DIFF
--- a/app/Contracts/DomainNameVerifier.php
+++ b/app/Contracts/DomainNameVerifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Exceptions\Domain\DomainNameVerificationException;
+use App\Values\CompanyDomain;
+
+interface DomainNameVerifier
+{
+    /**
+     * Verifies that a domain name exists.
+     *
+     * @param  CompanyDomain  $domain  The domain name to verify
+     *
+     * @throws DomainNameVerificationException If verification fails
+     */
+    public function verify(CompanyDomain $domain): void;
+}

--- a/app/Contracts/LinkVerifier.php
+++ b/app/Contracts/LinkVerifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Exceptions\Domain\LinkVerificationException;
+use App\Values\Link;
+
+interface LinkVerifier
+{
+    /**
+     * Verifies that a link exists.
+     *
+     * @param  Link  $link  The link to verify
+     *
+     * @throws LinkVerificationException If verification fails
+     */
+    public function verify(Link $link): void;
+}

--- a/app/Exceptions/Domain/DomainNameVerificationException.php
+++ b/app/Exceptions/Domain/DomainNameVerificationException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Domain;
+
+use Exception;
+use Throwable;
+
+final class DomainNameVerificationException extends Exception
+{
+    /**
+     * @param  non-empty-string  $message
+     */
+    public function __construct(
+        string $message,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/app/Exceptions/Domain/LinkVerificationException.php
+++ b/app/Exceptions/Domain/LinkVerificationException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Domain;
+
+use Exception;
+use Throwable;
+
+final class LinkVerificationException extends Exception
+{
+    /**
+     * @param  non-empty-string  $message
+     */
+    public function __construct(
+        string $message,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Contracts\LinkVerifier as LinkVerifierContract;
 use App\Models\EmployerProfile;
 use App\Models\JobSeekerProfile;
+use App\Services\LinkVerifier;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\ServiceProvider;
+use LogicException;
 use Override;
+use Uri\WhatWg\Url;
 
 final class AppServiceProvider extends ServiceProvider
 {
@@ -19,7 +23,21 @@ final class AppServiceProvider extends ServiceProvider
     #[Override]
     public function register(): void
     {
-        //
+        // Register the link verifier
+        $this->app->singleton(function (): LinkVerifierContract {
+            if (! is_string($appUrl = config('app.url'))) {
+                throw new LogicException('Application URL must be a string.');
+            }
+            if (
+                is_null($appUrl = Url::parse($appUrl)) ||
+                is_null($appHost = $appUrl->getAsciiHost()) ||
+                $appHost === ''
+            ) {
+                throw new LogicException('Application URL must have a domain name.');
+            }
+
+            return new LinkVerifier($appHost);
+        });
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Contracts\DomainNameVerifier as DomainNameVerifierContract;
 use App\Contracts\LinkVerifier as LinkVerifierContract;
 use App\Models\EmployerProfile;
 use App\Models\JobSeekerProfile;
+use App\Services\DomainNameVerifier;
 use App\Services\LinkVerifier;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -38,6 +40,9 @@ final class AppServiceProvider extends ServiceProvider
 
             return new LinkVerifier($appHost);
         });
+
+        // Register the domain name verifier
+        $this->app->bind(fn (): DomainNameVerifierContract => new DomainNameVerifier);
     }
 
     /**

--- a/app/Services/DomainNameVerifier.php
+++ b/app/Services/DomainNameVerifier.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\DomainNameVerifier as DomainNameVerifierContract;
+use App\Exceptions\Domain\DomainNameVerificationException;
+use App\Values\CompanyDomain;
+
+final class DomainNameVerifier implements DomainNameVerifierContract
+{
+    public function verify(CompanyDomain $domain): void
+    {
+        if (! checkdnsrr((string) $domain, 'A') && ! checkdnsrr((string) $domain, 'AAAA')) {
+            throw new DomainNameVerificationException(sprintf('The domain name given [%s] does not exist.', (string) $domain));
+        }
+    }
+}

--- a/app/Services/LinkVerifier.php
+++ b/app/Services/LinkVerifier.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\LinkVerifier as LinkVerifierContract;
+use App\Exceptions\Domain\LinkVerificationException;
+use App\Values\Link;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Uri\WhatWg\Url;
+
+final readonly class LinkVerifier implements LinkVerifierContract
+{
+    /**
+     * @param  non-empty-string  $localHost  Hostname of the current server.
+     */
+    public function __construct(private string $localHost) {}
+
+    public function verify(Link $link): void
+    {
+        $parsedLink = new Url((string) $link);
+        $foreignHost = (string) $parsedLink->getAsciiHost();
+
+        // Skip verification if resource is located on our servers
+        if ($foreignHost === $this->localHost) {
+            return;
+        }
+
+        $this->shieldFromSSRFattacks($parsedLink);
+
+        // Verify that the link exists
+        try {
+            $response = Http::timeout(1)->async(false)->head($parsedLink->toAsciiString());
+        } catch (ConnectionException) {
+            throw new LinkVerificationException("The resource at [{$parsedLink->toAsciiString()}] is not accessible.");
+        }
+        if (! $response->successful()) {
+            throw new LinkVerificationException("The resource at [{$parsedLink->toAsciiString()}] does not exist.");
+        }
+
+        // Verify that the link has accepted document type
+        $contentType = strtok($response->header('Content-Type'), ';');
+        if (! in_array(mb_trim((string) $contentType), [
+            'application/pdf',
+            'application/msword',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        ], true)) {
+            throw new LinkVerificationException("The resource at [{$parsedLink->toAsciiString()}] does not have an accepted type.");
+        }
+    }
+
+    /**
+     * Protects against server-side request forgery attacks.
+     *
+     * Verifies that the foreign host IP address is not within private ranges, loopback, and reserved addresses.
+     */
+    private function shieldFromSSRFattacks(Url $url): void
+    {
+        // Check if host is already an IP literal
+        if (filter_var(($host = $url->getAsciiHost() ?? ''), FILTER_VALIDATE_IP)) {
+            if (! filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                throw new LinkVerificationException('Target IP is not allowed.');
+            }
+
+            return;
+        }
+        // Resolve both A and AAAA records
+        if (($records = @dns_get_record($host, DNS_A | DNS_AAAA) ?: []) === []) {
+            throw new LinkVerificationException("Unable to resolve host [$host].");
+        }
+        foreach ($records as $record) {
+            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+            if ($ip && ! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                throw new LinkVerificationException('Target IP is not allowed.');
+            }
+        }
+    }
+}

--- a/app/Values/CompanyDomain.php
+++ b/app/Values/CompanyDomain.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Values;
 
+use App\Contracts\DomainNameVerifier;
+use App\Exceptions\Domain\DomainNameVerificationException;
 use App\Exceptions\Domain\RuleViolationException;
 use JsonSerializable;
 use Stringable;
@@ -27,15 +29,12 @@ final readonly class CompanyDomain implements JsonSerializable, Stringable
         return $this->value;
     }
 
-    /**
-     * Verifies the domain exists.
-     *
-     * @throws RuleViolationException If verification fails
-     */
-    public function verify(): void
+    public function verify(DomainNameVerifier $verifier): void
     {
-        if (! checkdnsrr($this->value, 'A') && ! checkdnsrr($this->value, 'AAAA')) {
-            throw new RuleViolationException("The domain name given [{$this->value}] does not exist.");
+        try {
+            $verifier->verify($this);
+        } catch (DomainNameVerificationException $e) {
+            throw new RuleViolationException("Fake domain provided: {$e->getMessage()}");
         }
     }
 }

--- a/app/Values/Link.php
+++ b/app/Values/Link.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Values;
 
+use App\Contracts\LinkVerifier;
+use App\Exceptions\Domain\LinkVerificationException;
 use App\Exceptions\Domain\RuleViolationException;
 use App\Exceptions\Domain\ValidationFailedException;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Support\Facades\Http;
 use JsonSerializable;
 use Stringable;
 use Uri\WhatWg\Url;
@@ -51,59 +51,12 @@ final readonly class Link implements JsonSerializable, Stringable
      *
      * @throws RuleViolationException If verification fails
      */
-    public function verify(): void
+    public function verify(LinkVerifier $verifier): void
     {
-        $url = new Url($this->value);
-
-        // Skip verification if resource is located in our domain
-        $appHost = is_string($appUrl = config('app.url')) ? new Url($appUrl)->getAsciiHost() : null;
-        if ($url->getAsciiHost() === $appHost) {
-            return;
-        }
-
-        $this->shieldFromSSRFattacks($url);
-
-        // Verify that link exists
         try {
-            $response = Http::timeout(1)->async(false)->head($url->toAsciiString());
-        } catch (ConnectionException) {
-            throw new RuleViolationException("The resource at [{$url->toAsciiString()}] is not accessible.");
-        }
-        if (! $response->successful()) {
-            throw new RuleViolationException("The resource at [{$url->toAsciiString()}] does not exist.");
-        }
-
-        // Verify that link has accepted document type
-        $contentType = strtok($response->header('Content-Type'), ';');
-        if (! in_array(mb_trim((string) $contentType), ['application/pdf', 'application/msword'], true)) {
-            throw new RuleViolationException("The resource at [{$url->toAsciiString()}] does not have an accepted type.");
-        }
-    }
-
-    /**
-     * Protects against server-side request forgery attacks.
-     *
-     * Verifies link's host IP address is not within private ranges, loopback, and reserved addresses.
-     */
-    private function shieldFromSSRFattacks(Url $url): void
-    {
-        // Check if host is already an IP literal
-        if (filter_var(($host = $url->getAsciiHost() ?? ''), FILTER_VALIDATE_IP)) {
-            if (! filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-                throw new RuleViolationException('Target IP is not allowed.');
-            }
-
-            return;
-        }
-        // Resolve both A and AAAA records
-        if (($records = dns_get_record($host, DNS_A | DNS_AAAA) ?: []) === []) {
-            throw new RuleViolationException("Unable to resolve host [$host].");
-        }
-        foreach ($records as $record) {
-            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
-            if ($ip && ! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-                throw new RuleViolationException('Target IP is not allowed.');
-            }
+            $verifier->verify($this);
+        } catch (LinkVerificationException $e) {
+            throw new RuleViolationException("Fake link provided: {$e->getMessage()}");
         }
     }
 }


### PR DESCRIPTION
- Create a link verification service abstraction to make link verification variable
- Move current link verification logic into an implementation of the abstraction
- Update Link's 'verify' method to use the new service for verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Link and domain value objects now delegate verification to dedicated verifier services for centralized checks.
  * Verification responsibilities moved out of value objects into services, unifying DNS and network validation.

* **New Features**
  * Added verifier implementations and domain-specific exception types for clearer failure reasons.
  * Improved error reporting when links or domains are rejected (e.g., prefixed messages like “Fake link/domain provided…”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->